### PR TITLE
exec-sync is deprecated. use execSync or native (node 0.11+) 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var exec = require('exec-sync')
+var exec = require('child_process').execSync || require('execSync');
 
 module.exports = function(){
   var self = this

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "mocha": "^1.21.4"
   },
   "dependencies": {
-    "execSync: "^1.0.2"
+    "execSync": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "mocha": "^1.21.4"
   },
   "dependencies": {
-    "exec-sync": "^0.1.6"
+    "execSync: "^1.0.2"
   }
 }


### PR DESCRIPTION
based on readme for exec-sync: https://github.com/jeremyfa/node-exec-sync

and comment here: https://github.com/mgutz/execSync/issues/20#issuecomment-46823036