### PR TITLE
fix: ignore "could not find" message in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(){
 
 function isExec(command){
   try{
-    exec(command)
+    exec(command, { stdio: 'ignore' })
     return true
   }
   catch (_e){

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Finds first available shell command from a list.",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha test/all.js"
+    "test": "mocha test/all.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-exec",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Finds first available shell command from a list.",
   "main": "index.js",
   "scripts": {

--- a/test/all.js
+++ b/test/all.js
@@ -1,16 +1,35 @@
 var expect = require("expect.js")
+var platform = require('os').platform()
 var shell = require('./../')
 
-it("returns the first command available", function(){
-  var result = shell("./test/shims/foo", "./test/shims/baz", "./test/shims/bar")
-  expect(result).to.be('./test/shims/foo')
-})
+if (/^win/.test(platform)){
+  describe('Windows', function(){
+    it("returns the first command available", function(){
+      var result = shell("unknown", "explorer", "still-unknown")
+      expect(result).to.be('explorer')
+    })
 
-it("is okay if one of the bins is missing", function(){
-  var result = shell(["./test/shims/baz", "./test/shims/bar"])
-  expect(result).to.be('./test/shims/bar')
-})
+    it("is okay if one of the bins is missing", function(){
+      var result = shell(["unknown", "explorer"])
+      expect(result).to.be('explorer')
+    })
 
-it("returns null if command was not found", function(){
-  expect(shell(["./test/shims/baz"])).to.be(null)
-})
+    it("returns null if command was not found", function(){
+      expect(shell(["unknown"])).to.be(null)
+    })
+  })
+} else {
+  it("returns the first command available", function(){
+    var result = shell("./test/shims/foo", "./test/shims/baz", "./test/shims/bar")
+    expect(result).to.be('./test/shims/foo')
+  })
+
+  it("is okay if one of the bins is missing", function(){
+    var result = shell(["./test/shims/baz", "./test/shims/bar"])
+    expect(result).to.be('./test/shims/bar')
+  })
+
+  it("returns null if command was not found", function(){
+    expect(shell(["./test/shims/baz"])).to.be(null)
+  })
+}


### PR DESCRIPTION
In Windows, if `where xxx` cannot find the file,
it will emit `INFO: Could not find files for the given pattern(s).` to the console.

Add `stdio: 'ignore'` to prevent that message from printing out

Fixes #5